### PR TITLE
feat: Add viewScope and fix call-site for renderState

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ VectorState is an interface denoting a model class representing the view's state
 
 * **VectorFragment**
 
-Vector provides an abstract `VectorFragment` class extending from AndroidX's Fragment class. A `VectorFragment` has a convenient `fragmentScope` coroutine scope, which can be used to easily launch Coroutines from a Fragment.
+Vector provides an abstract `VectorFragment` class extending from AndroidX's Fragment class. A `VectorFragment` has a convenient coroutine scope, which can be used to easily launch Coroutines from a Fragment.
 
 ## Example
 
@@ -45,8 +45,7 @@ class MyFragment: VectorFragment() {
 
     private val myViewModel: MyViewModel by fragmentViewModel()
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         renderState(viewModel) { state ->
             toast(state.message)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ buildscript {
             "liveData"          : "androidx.lifecycle:lifecycle-livedata:${versions.lifecycle}",
             "lifecycle"         : "androidx.lifecycle:lifecycle-extensions:${versions.lifecycle}",
             "lifecycleTest"     : "androidx.arch.core:core-testing:${versions.lifecycleTest}",
+            "lifecycleRuntime"  : "androidx.lifecycle:lifecycle-runtime-ktx:${versions.lifecycle}",
             "vmSavedState"      : "androidx.lifecycle:lifecycle-viewmodel-savedstate:${versions.vmSavedState}",
             "ktxCore"           : "androidx.core:core-ktx:${versions.ktxCore}",
             "recyclerView"      : "androidx.recyclerview:recyclerview:${versions.recyclerView}",

--- a/docs/components/vector-fragment.md
+++ b/docs/components/vector-fragment.md
@@ -2,9 +2,9 @@
 
 Vector Fragment is an abstract class that extends the AndroidX `Fragment` class.
 
-You are not required to use it, the only benefit it offers is that it has a convenient `fragmentScope` Couroutine Scope which can be used to easily launch Coroutines.
+You are not required to use it, the only benefit it offers is that it has convenient `fragmentScope` and `viewScope` Couroutine Scopes which can be used to easily launch Coroutines.
 
-`VectorFragment` class also has an abstract `renderState(state: S, renderer: (S) -> Unit)` method, which should be overridden by subclasses. It is supposed to be the place where Views update themselves. You are free to choose your own implementation and not extend from `VectorFragment` at all.
+`VectorFragment` class also has an abstract `renderState(state: S, renderer: (S) -> Unit)` method, which should be used by subclasses in their `onViewCreated` callback. It is supposed to be the place where Views update themselves. You are free to choose your own implementation and not extend from `VectorFragment` at all.
 
 An example of how the `renderState` function should look like:
 
@@ -13,12 +13,14 @@ class UsersListFragment: VectorFragment() {
 
     private val viewModel: UserViewModel by viewModel()
 
-    override fun onCreate(...) {
+    override fun onViewCreated(...) {
         renderState(viewModel) { state ->
             // Update your views here
         }
     }
 }
 ```
+
+The `renderState` method internally launches a coroutine in a Coroutine Scope scoped to fragment's view-lifecycle. Therefore it **must** be called in the `onViewCreated` method.
 
 Vector is not opinionated about what should be used as Views in an app, so please feel free to use whatever you like. However, the `VectorViewModel` class exposes the current state observable as a `Kotlin Flow` object, so it helps if your View object is a `CoroutineScope`.

--- a/docs/usage/basics.md
+++ b/docs/usage/basics.md
@@ -170,9 +170,9 @@ Now that we have our ViewModel, we can start observing state changes. To do this
 class NotesListFragment: VectorFragment() {
   private val viewModel: NotesListViewModel by fragmentViewModel()
 
-  override fun onCreate() {
+  override fun onViewCreated() {
     ...
-    fragmentScope.launch {
+    viewScope.launch {
       viewModel.state.collect { state ->
         recyclerViewAdapter.submitList(state.notes)
       }
@@ -181,7 +181,7 @@ class NotesListFragment: VectorFragment() {
 }
 ```
 
-The `fragmentScope` property is a Coroutine Scope which is cancelled when the Fragment's `onDestroy()` callback is called.
+The `viewScope` property is a Coroutine Scope which is tied to the Fragment's view-lifecycle.
 
 This action of subscribing to state changes can be done more concisely using the `renderState()` method in the `VectorFragment` class.
 
@@ -189,7 +189,7 @@ This action of subscribing to state changes can be done more concisely using the
 class NotesListFragment: VectorFragment() {
   private val viewModel: NotesListViewModel by fragmentViewModel()
 
-  override fun onCreate() {
+  override fun onViewCreated() {
     ...
     renderState(viewModel) { state ->
       recyclerViewAdapter.submitList(state.notes)

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -15,6 +15,7 @@ android {
         versionName buildConfig.versionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
+        vectorDrawables.useSupportLibrary = true
     }
 
     signingConfigs {

--- a/sampleapp/src/main/java/com/haroldadmin/sampleapp/MainActivity.kt
+++ b/sampleapp/src/main/java/com/haroldadmin/sampleapp/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.navigation.NavController
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
+import androidx.navigation.ui.onNavDestinationSelected
 import androidx.navigation.ui.setupWithNavController
 import com.haroldadmin.sampleapp.databinding.ActivityMainBinding
 
@@ -21,6 +22,10 @@ class MainActivity : AppCompatActivity() {
         binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
 
         val appBarConfig = AppBarConfiguration(navController.graph)
-        binding.toolbar.setupWithNavController(navController, appBarConfig)
+        binding.toolbar.apply {
+            setupWithNavController(navController, appBarConfig)
+            inflateMenu(R.menu.menu_main)
+            setOnMenuItemClickListener { item -> item.onNavDestinationSelected(navController)}
+        }
     }
 }

--- a/sampleapp/src/main/java/com/haroldadmin/sampleapp/about/AboutFragment.kt
+++ b/sampleapp/src/main/java/com/haroldadmin/sampleapp/about/AboutFragment.kt
@@ -1,0 +1,36 @@
+package com.haroldadmin.sampleapp.about
+
+import android.animation.ObjectAnimator
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.animation.LinearInterpolator
+import com.haroldadmin.sampleapp.R
+import com.haroldadmin.sampleapp.databinding.FragmentAboutBinding
+import com.haroldadmin.vector.VectorFragment
+
+class AboutFragment : VectorFragment() {
+
+    private lateinit var binding: FragmentAboutBinding
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        binding = FragmentAboutBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        renderState(AboutState()) { state ->
+            ObjectAnimator
+                .ofFloat(binding.logo, View.ROTATION, 0f, 360f)
+                .apply {
+                    duration = 3000
+                    repeatCount = ObjectAnimator.INFINITE
+                    interpolator = LinearInterpolator()
+                }
+                .also { it.start()}
+
+            binding.debugInfo.text = getString(R.string.debugInformation, state.appVersion, state.libraryVersion)
+        }
+    }
+}

--- a/sampleapp/src/main/java/com/haroldadmin/sampleapp/about/AboutState.kt
+++ b/sampleapp/src/main/java/com/haroldadmin/sampleapp/about/AboutState.kt
@@ -1,0 +1,9 @@
+package com.haroldadmin.sampleapp.about
+
+import com.haroldadmin.sampleapp.BuildConfig
+import com.haroldadmin.vector.VectorState
+
+data class AboutState(
+    val appVersion: String = BuildConfig.VERSION_NAME,
+    val libraryVersion: String = com.haroldadmin.vector.BuildConfig.VERSION_NAME
+) : VectorState

--- a/sampleapp/src/main/java/com/haroldadmin/sampleapp/addEditEntity/AddEditEntityFragment.kt
+++ b/sampleapp/src/main/java/com/haroldadmin/sampleapp/addEditEntity/AddEditEntityFragment.kt
@@ -70,8 +70,8 @@ class AddEditEntityFragment : VectorFragment() {
         return binding.root
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         renderState(viewModel) { state ->
             when (state) {
                 is AddEditEntityState.AddEntity -> {

--- a/sampleapp/src/main/java/com/haroldadmin/sampleapp/entities/EntitiesFragment.kt
+++ b/sampleapp/src/main/java/com/haroldadmin/sampleapp/entities/EntitiesFragment.kt
@@ -15,7 +15,6 @@ import com.haroldadmin.sampleapp.utils.show
 import com.haroldadmin.vector.VectorFragment
 import com.haroldadmin.vector.activityViewModel
 import com.haroldadmin.vector.fragmentViewModel
-import com.haroldadmin.vector.loggers.logd
 import dagger.android.support.AndroidSupportInjection
 import javax.inject.Inject
 

--- a/sampleapp/src/main/java/com/haroldadmin/sampleapp/entities/EntitiesFragment.kt
+++ b/sampleapp/src/main/java/com/haroldadmin/sampleapp/entities/EntitiesFragment.kt
@@ -15,6 +15,7 @@ import com.haroldadmin.sampleapp.utils.show
 import com.haroldadmin.vector.VectorFragment
 import com.haroldadmin.vector.activityViewModel
 import com.haroldadmin.vector.fragmentViewModel
+import com.haroldadmin.vector.loggers.logd
 import dagger.android.support.AndroidSupportInjection
 import javax.inject.Inject
 
@@ -43,8 +44,26 @@ class EntitiesFragment : VectorFragment() {
         super.onAttach(context)
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        binding = FragmentEntitiesBinding.inflate(inflater, container, false)
+
+        binding.rvEntities.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = entitiesAdapter
+            addItemDecoration(DividerItemDecoration(requireContext(), LinearLayoutManager.VERTICAL))
+        }
+
+        binding.addEntity.setOnClickListener {
+            findNavController().navigate(EntitiesFragmentDirections.addEntity())
+        }
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+
+        viewModel.getAllEntities()
+
         renderState(viewModel) { state ->
             entitiesAdapter.submitList(state.entities)
             if (state.entities.isNullOrEmpty()) {
@@ -60,22 +79,5 @@ class EntitiesFragment : VectorFragment() {
             }
             appViewModel.updateNumberOfEntities()
         }
-        viewModel.getAllEntities()
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        binding = FragmentEntitiesBinding.inflate(inflater, container, false)
-
-        binding.rvEntities.apply {
-            layoutManager = LinearLayoutManager(requireContext())
-            adapter = entitiesAdapter
-            addItemDecoration(DividerItemDecoration(requireContext(), LinearLayoutManager.VERTICAL))
-        }
-
-        binding.addEntity.setOnClickListener {
-            findNavController().navigate(EntitiesFragmentDirections.addEntity())
-        }
-
-        return binding.root
     }
 }

--- a/sampleapp/src/main/res/drawable/ic_vector.xml
+++ b/sampleapp/src/main/res/drawable/ic_vector.xml
@@ -1,0 +1,26 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="54dp"
+    android:height="54dp"
+    android:viewportWidth="378"
+    android:viewportHeight="386">
+  <path
+      android:pathData="M189,381.587C84.846,381.587 0.413,297.154 0.413,193C0.413,88.846 84.846,4.413 189,4.413C293.154,4.413 377.587,88.846 377.587,193C377.587,297.154 293.154,381.587 189,381.587ZM189,326.12C262.52,326.12 322.12,266.52 322.12,193C322.12,119.48 262.52,59.88 189,59.88C115.48,59.88 55.88,119.48 55.88,193C55.88,266.52 115.48,326.12 189,326.12Z"
+      android:strokeWidth="1"
+      android:fillColor="#1DE9B6"
+      android:fillType="evenOdd"
+      android:strokeColor="#00000000"/>
+  <path
+      android:pathData="M188.416,326.12L162.537,351.082C161.688,351.928 161.264,352.774 161.264,353.62C161.264,354.466 161.688,355.312 162.537,356.158L188.416,381.12"
+      android:strokeWidth="6"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:fillType="evenOdd"
+      android:strokeLineCap="square"/>
+  <path
+      android:pathData="M189.716,59.88L214.67,34.918C215.488,34.072 215.898,33.226 215.898,32.38C215.898,31.534 215.488,30.688 214.67,29.842L189.716,4.88"
+      android:strokeWidth="6"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:fillType="evenOdd"
+      android:strokeLineCap="square"/>
+</vector>

--- a/sampleapp/src/main/res/layout/fragment_about.xml
+++ b/sampleapp/src/main/res/layout/fragment_about.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ImageView
+            android:id="@+id/logo"
+            android:layout_width="96dp"
+            android:layout_height="96dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginRight="16dp"
+            android:contentDescription="@string/descriptionLogo"
+            app:layout_constraintBottom_toTopOf="@+id/subtitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.25"
+            app:layout_constraintVertical_chainStyle="packed"
+            app:srcCompat="@drawable/ic_vector" />
+
+        <TextView
+            android:id="@+id/subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginTop="32dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginRight="16dp"
+            android:text="@string/subtitleText"
+            android:textAlignment="center"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            app:fontFamily="sans-serif-medium"
+            app:layout_constraintBottom_toTopOf="@+id/debugInfo"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/logo" />
+
+        <TextView
+            android:id="@+id/debugInfo"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginRight="16dp"
+            android:textAlignment="center"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/subtitle"
+            tools:text="App Version: 0.1\nLibrary Version: 0.1" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/sampleapp/src/main/res/layout/fragment_add_entity.xml
+++ b/sampleapp/src/main/res/layout/fragment_add_entity.xml
@@ -76,7 +76,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             android:layout_margin="16dp"
-            android:src="@drawable/ic_round_check_24px" />
+            app:srcCompat="@drawable/ic_round_check_24px" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/sampleapp/src/main/res/layout/fragment_entities.xml
+++ b/sampleapp/src/main/res/layout/fragment_entities.xml
@@ -32,7 +32,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="16dp"
-            android:src="@drawable/ic_round_add_24px"
+            app:srcCompat="@drawable/ic_round_add_24px"
             app:fabSize="auto"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />

--- a/sampleapp/src/main/res/menu/menu_main.xml
+++ b/sampleapp/src/main/res/menu/menu_main.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@id/aboutFragment"
+        android:title="About" />
+</menu>

--- a/sampleapp/src/main/res/navigation/nav_graph.xml
+++ b/sampleapp/src/main/res/navigation/nav_graph.xml
@@ -42,4 +42,9 @@
             app:nullable="false"
             android:defaultValue="0L" />
     </fragment>
+    <fragment
+        android:id="@+id/aboutFragment"
+        android:name="com.haroldadmin.sampleapp.about.AboutFragment"
+        android:label="About"
+        tools:layout="@layout/fragment_about"/>
 </navigation>

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -7,4 +7,7 @@
     <string name="entitiesFragmentEmptyListMessage">This list is empty.\nAdd some entities by tapping the button below!
     </string>
     <string name="entityChangesSavedMessage">Changes saved!</string>
+    <string name="subtitleText">Built with Vector</string>
+    <string name="descriptionLogo">Library logo</string>
+    <string name="debugInformation">"App Version: %1$s \nLibrary Version: %2$s</string>
 </resources>

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     implementation libs.appCompat
     implementation libs.vmSavedState
     implementation libs.viewModel
+    implementation libs.lifecycleRuntime
 
     testImplementation libs.junit
     testImplementation libs.coroutinesTest

--- a/vector/src/main/java/com/haroldadmin/vector/VectorFragment.kt
+++ b/vector/src/main/java/com/haroldadmin/vector/VectorFragment.kt
@@ -3,9 +3,12 @@ package com.haroldadmin.vector
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import com.haroldadmin.vector.loggers.androidLogger
-import com.haroldadmin.vector.loggers.logd
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 
 /**
  * A Fragment which has a convenient fragmentScope property

--- a/vector/src/main/java/com/haroldadmin/vector/VectorFragment.kt
+++ b/vector/src/main/java/com/haroldadmin/vector/VectorFragment.kt
@@ -1,6 +1,9 @@
 package com.haroldadmin.vector
 
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import com.haroldadmin.vector.loggers.androidLogger
+import com.haroldadmin.vector.loggers.logd
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.collect
 
@@ -12,10 +15,21 @@ import kotlinx.coroutines.flow.collect
 abstract class VectorFragment : Fragment() {
 
     /**
-     * A [kotlinx.coroutines.CoroutineScope] associated with the lifecycle of this fragment. The scope is cancelled when
+     * A [CoroutineScope] associated with the lifecycle of this fragment. The scope is cancelled when
      * [onDestroy] of this Fragment has been called.
      */
-    protected open val fragmentScope by lazy { CoroutineScope(Dispatchers.Main + Job()) }
+    protected open val fragmentScope: CoroutineScope by lazy { CoroutineScope(Dispatchers.Main + Job()) }
+
+    /**
+     * A [CoroutineScope] associated with the view-lifecycle of this fragment. The scope is cancelled
+     * when [onDestroyView] of this Fragment has been called, and created when [onCreateView] is called.
+     *
+     * It delegates to the lifecycle-runtime library's [androidx.lifecycle.lifecycleScope] extension
+     */
+    protected open val viewScope: CoroutineScope
+        get() = viewLifecycleOwner.lifecycleScope
+
+    protected open val logger by lazy { androidLogger(this::class.java.simpleName) }
 
     /**
      * Renders the UI based on the given [state] parameter using the [renderer] block. If your fragment is tied to a
@@ -32,14 +46,21 @@ abstract class VectorFragment : Fragment() {
 
     /**
      * Renders the UI based on emitted state updates from the given [viewModel] using the [renderer]
-     * block.
+     * block. **MUST BE CALLED IN onViewCreated()**
+     *
+     * Launches a coroutine in [viewScope] which collects state updates from the given [viewModel] and calls
+     * the [renderer] method on it. Since the renderer method might contain references to views, and also since
+     * this method should only run while the view of the fragment is available, it is launched in the [viewScope]
+     * rather than the [fragmentScope]. As such, it must be called in [onViewCreated] after the [viewScope] is
+     * available and the view can be updated. The collection of state updates automatically stops when
+     * [onDestroyView] is called.
      *
      * @param viewModel The ViewModel whose [VectorViewModel.state] flow is used to receive state updates and
      * render the UI
      * @param renderer The method which updates the UI
      */
     protected inline fun <S : VectorState> renderState(viewModel: VectorViewModel<S>, crossinline renderer: (S) -> Unit) {
-        fragmentScope.launch {
+        viewScope.launch {
             viewModel.state.collect { state ->
                 renderer(state)
             }

--- a/vector/src/main/java/com/haroldadmin/vector/VectorFragment.kt
+++ b/vector/src/main/java/com/haroldadmin/vector/VectorFragment.kt
@@ -37,7 +37,7 @@ abstract class VectorFragment : Fragment() {
     /**
      * Renders the UI based on the given [state] parameter using the [renderer] block. If your fragment is tied to a
      * [VectorViewModel] then consider using the overloaded version of the method which takes in a viewModel as an
-     * input parameter.
+     * input parameter. **Must be called after the Fragment view has been created ([onViewCreated])**
      *
      * @param state The state instance using which the UI should be rendered
      * @param renderer The method which updates the UI state

--- a/vector/src/main/java/com/haroldadmin/vector/loggers/Logger.kt
+++ b/vector/src/main/java/com/haroldadmin/vector/loggers/Logger.kt
@@ -23,7 +23,6 @@ interface Logger {
      * @param message The message to be logged
      */
     fun log(message: String, level: Level = Level.DEBUG)
-
 }
 
 inline fun Logger.logd(crossinline messageProducer: () -> String) {


### PR DESCRIPTION
Fixes #21

- Adds a new Coroutine Scope `viewScope` which is scoped to the Fragment's View lifecycle.
- Use `viewScope` to launch the coroutine that collects ViewModel state updates in `renderState`
- Add docs regarding which lifecycle callback should be used to call `renderState`
- Add about page to the app to validate usage of simple `renderState`