### PR TITLE
Make StateProcessor.drain wait until all side-effect coroutines have been processed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,14 @@ buildscript {
             "compileSdk" : 29,
             "minSdk"     : 15,
             "targetSdk"  : 29,
-            "kotlin"     : "1.3.71",
+            "kotlin"     : "1.3.72",
             "agp"        : "3.6.3",
             "versionCode": 13,
             "versionName": "0.6.2"
     ]
 
     ext.versions = [
-            "coroutines"        : "1.3.5",
+            "coroutines"        : "1.3.6",
             "appCompat"         : "1.1.0",
             "lifecycle"         : "2.2.0",
             "coreTest"          : "2.0.0",

--- a/vector/src/main/java/com/haroldadmin/vector/VectorViewModel.kt
+++ b/vector/src/main/java/com/haroldadmin/vector/VectorViewModel.kt
@@ -46,7 +46,7 @@ abstract class VectorViewModel<S : VectorState>(
     val state: Flow<S> by lazy {
         stateStore
             .stateObservable
-            .asFlow()
+            .asFlow<S>()
             .onEach {
                 logger.logd { "State: $it" }
             }

--- a/vector/src/main/java/com/haroldadmin/vector/VectorViewModel.kt
+++ b/vector/src/main/java/com/haroldadmin/vector/VectorViewModel.kt
@@ -46,7 +46,7 @@ abstract class VectorViewModel<S : VectorState>(
     val state: Flow<S> by lazy {
         stateStore
             .stateObservable
-            .asFlow<S>()
+            .asFlow()
             .onEach {
                 logger.logd { "State: $it" }
             }

--- a/vector/src/main/java/com/haroldadmin/vector/state/StateProcessor.kt
+++ b/vector/src/main/java/com/haroldadmin/vector/state/StateProcessor.kt
@@ -1,50 +1,27 @@
 package com.haroldadmin.vector.state
 
 import com.haroldadmin.vector.VectorState
-import kotlinx.coroutines.CoroutineScope
 
 /**
- * Represents actions that can access state or mutate state
- */
-internal interface Action<S : VectorState>
-
-/**
- * Represents an action that mutates the current state
- *
- * @param reducer A lambda with the current state as the receiver, which produces a new state
- */
-internal inline class SetStateAction<S : VectorState>(val reducer: suspend S.() -> S) :
-    Action<S>
-
-/**
- * Represents an action that can access current state and perform some action with it
- *
- * @param block A lambda that receives the current state as its parameter, and performs some action
- * using it
- */
-internal inline class GetStateAction<S : VectorState>(val block: suspend (S) -> Unit) :
-    Action<S>
-
-/**
- * An entity that manages any [Action] on state.
+ * An entity that manages any action on state.
  *
  * @param S The state type implementing [VectorState]
  *
- * A [SetStateAction] is be processed before any existing [GetStateAction] in the queue
- * A [GetStateAction] is given the latest state value as it's parameter
+ * A [reducer] is be processed before any existing [action] in the queue
+ * A [action] is given the latest state value as it's parameter
  */
-interface StateProcessor<S : VectorState> : CoroutineScope {
+interface StateProcessor<S : VectorState> {
 
     /**
-     * Offer a [SetStateAction] to this processor. This action will be processed as soon as
-     * possible, before all existing [GetStateAction] waiting in the queue, if any.
+     * Offer a [reducer] to this processor. This action will be processed as soon as
+     * possible, before all existing [action] waiting in the queue, if any.
      *
      * @param reducer The action to be offered
      */
-    fun offerSetAction(reducer: suspend S.() -> S)
+    fun offerSetAction(reducer: reducer<S>)
 
     /**
-     * Offer a [GetStateAction] to this processor. The state parameter supplied to this action
+     * Offer a [action] to this processor. The state parameter supplied to this action
      * shall be the latest state value at the time of processing this action.
      *
      * These actions are treated as side effects. When such an action is received, a separate coroutine is launched
@@ -52,10 +29,14 @@ interface StateProcessor<S : VectorState> : CoroutineScope {
      * in order, but their completion depends on how long it takes to process them. They will be processed in the
      * coroutine context of their state processor.
      */
-    fun offerGetAction(action: suspend (S) -> Unit)
+    fun offerGetAction(action: action<S>)
 
     /**
      * Cleanup any resources held by this processor.
      */
     fun clearProcessor()
 }
+
+internal typealias reducer<S> = suspend S.() -> S
+
+internal typealias action<S> = suspend (S) -> Unit

--- a/vector/src/main/java/com/haroldadmin/vector/state/StateProcessorFactory.kt
+++ b/vector/src/main/java/com/haroldadmin/vector/state/StateProcessorFactory.kt
@@ -24,7 +24,7 @@ internal object StateProcessorFactory {
         coroutineContext: CoroutineContext
     ): StateProcessor<S> {
         return SelectBasedStateProcessor(
-            isLazy = false,
+            shouldStartImmediately = true,
             stateHolder = stateHolder,
             logger = logger,
             coroutineContext = coroutineContext

--- a/vector/src/test/java/com/haroldadmin/vector/state/SelectBasedStateProcessorTest.kt
+++ b/vector/src/test/java/com/haroldadmin/vector/state/SelectBasedStateProcessorTest.kt
@@ -1,9 +1,7 @@
 package com.haroldadmin.vector.state
 
-import com.haroldadmin.vector.Vector
 import com.haroldadmin.vector.extensions.awaitCompletion
 import com.haroldadmin.vector.loggers.systemOutLogger
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job


### PR DESCRIPTION
StateProcessor's `drain` method now waits until all coroutines launched to process get-state actions complete. This is useful for testing and benchmarking purposes, where you can enqueue all the jobs to be processed beforehand, and then call `drain()` to wait until they have all completed.